### PR TITLE
Add SEO plugin and meta tags management to pages

### DIFF
--- a/app/blueprints/pages/article.yml
+++ b/app/blueprints/pages/article.yml
@@ -20,6 +20,7 @@ columns:
   - width: 5/12
     icon: text
     fields:
+      seo: fields/seo/meta
       publishedAt:
         label: Publié le
         type: date

--- a/app/blueprints/pages/blog.yml
+++ b/app/blueprints/pages/blog.yml
@@ -20,4 +20,5 @@ columns:
         templates: article
   - width: 5/12
     icon: text
-    fields: []
+    fields:
+      seo: fields/seo/meta

--- a/app/blueprints/pages/home.yml
+++ b/app/blueprints/pages/home.yml
@@ -32,3 +32,4 @@ columns:
     label: Content
     fields:
       submenu: fields/submenu
+      seo: fields/seo/meta

--- a/app/blueprints/pages/legal-notice.yml
+++ b/app/blueprints/pages/legal-notice.yml
@@ -19,4 +19,5 @@ columns:
     icon: text
     label: Content
     width: 5/12
-    fields: []
+    fields:
+      seo: fields/seo/meta

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,7 @@
     },
     "require": {
         "php": "^8.4",
+        "benjaminhaeberli/kirby-seo": "^1.0",
         "funkjedi/composer-include-files": "^1.1",
         "getkirby/cms": "^5.0",
         "getkirby/staticache": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a33eaad2eb7b0078fc3196b7c30de75",
+    "content-hash": "b29df8837970a0d3e80762dca87a1646",
     "packages": [
         {
             "name": "adhocore/cli",
@@ -78,6 +78,68 @@
                 }
             ],
             "time": "2025-05-11T13:23:54+00:00"
+        },
+        {
+            "name": "benjaminhaeberli/kirby-seo",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/benjaminhaeberli/kirby-seo.git",
+                "reference": "d2aab1ebec51e639e32412c4101088d4925bb85a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/benjaminhaeberli/kirby-seo/zipball/d2aab1ebec51e639e32412c4101088d4925bb85a",
+                "reference": "d2aab1ebec51e639e32412c4101088d4925bb85a",
+                "shasum": ""
+            },
+            "require": {
+                "funkjedi/composer-include-files": "^1.1",
+                "getkirby/cms": "^4.0.1 || ^5.0",
+                "getkirby/composer-installer": "^1.2.1",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.17",
+                "pestphp/pest": "^3.0",
+                "phpstan/phpstan": "^1.12",
+                "rector/rector": "^1.0"
+            },
+            "type": "kirby-plugin",
+            "extra": {
+                "include_files": [
+                    "src/bootstrap.php"
+                ],
+                "kirby-cms-path": false
+            },
+            "autoload": {
+                "psr-4": {
+                    "BenjaminHaeberli\\KirbySeo\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Haeberli",
+                    "email": "hello@benjaminhaeberli.ch",
+                    "homepage": "https://benjaminhaeberli.ch/"
+                }
+            ],
+            "description": "🔎 Minimal SEO plugin for Kirby CMS – for PHP lovers.",
+            "keywords": [
+                "kirby",
+                "kirby-plugin",
+                "php",
+                "seo"
+            ],
+            "support": {
+                "issues": "https://github.com/benjaminhaeberli/kirby-seo/issues",
+                "source": "https://github.com/benjaminhaeberli/kirby-seo/tree/v1.0.0"
+            },
+            "time": "2026-02-02T00:06:21+00:00"
         },
         {
             "name": "christian-riesen/base32",

--- a/resources/views/snippets/header.php
+++ b/resources/views/snippets/header.php
@@ -8,8 +8,7 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0 shrink-to-fit=no">
-    <title><?= $page->title() ?> | <?= $site->title() ?></title>
-    <meta name="description" content="<?= $site->description() ?>">
+    <?php snippet('seo/meta') ?>
     <link rel="icon" href="/favicon/favicon.svg">
     <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg">
     <link rel="icon" type="image/png" href="/favicon/favicon.svg">


### PR DESCRIPTION
## Summary
Integrates the Kirby SEO plugin to manage SEO metadata across all pages, replacing hardcoded meta tags with a centralized, field-based approach.

## Changes
- **Dependencies**: Added `benjaminhaeberli/kirby-seo` v1.0.0 plugin to composer.json and lock file
- **Page Blueprints**: Added `seo: fields/seo/meta` field to all page types:
  - `article.yml` - Added SEO field to article pages
  - `blog.yml` - Added SEO field to blog listing pages
  - `home.yml` - Added SEO field to homepage
  - `legal-notice.yml` - Added SEO field to legal notice pages
- **Header Template**: Replaced hardcoded title and description meta tags with `snippet('seo/meta')` call, delegating SEO rendering to the plugin

## Implementation Details
- The SEO plugin provides a reusable `fields/seo/meta` blueprint field for consistent metadata management
- The `seo/meta` snippet (provided by the plugin) handles rendering of all SEO-related meta tags
- This approach allows content editors to manage SEO metadata per-page through the Kirby panel instead of relying on site-wide defaults

https://claude.ai/code/session_01FWHXinqUq7b7TpkiMwMkoF