### PR TITLE
Fix php-icons scanning and improve UI consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ fieldName:
 <?= icon('lucide:heart', ['class' => 'text-rose-400']) ?>
 ```
 
+> **Important** : php-icons ne scanne que les fichiers `.php`. Les icônes référencées dynamiquement depuis le contenu Kirby (fichiers `.txt`) doivent être déclarées dans `src/content-icons.php` pour être détectées lors du build.
+
 ## GitMoji
 
 Ce projet utilise GitMoji pour les commits:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ export PATH=/opt/php8.1/bin:$PATH
 - [Laravel/Pint](https://github.com/laravel/pint) → Opinionated PHP code style fixer for minimalists built on top of [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer)
 - [Prettier](https://prettier.io/) → Opinionated code formatter
 
+### Icons (php-icons)
+
+Icons are managed by [php-icons](https://github.com/yassinedoghri/php-icons), which scans PHP files for `icon()` calls and fetches SVG data from the Iconify API.
+
+> **Important :** php-icons only scans `.php` files. Icons referenced dynamically from Kirby content files (`.txt`) must be declared in `src/content-icons.php` to be discovered during the build.
+
 ## Documentation 📒
 
 - [GitMoji](https://gitmoji.dev/) → Emoji guide for GIT commit messages

--- a/php-icons.php
+++ b/php-icons.php
@@ -8,8 +8,7 @@ return PHPIconsConfig::configure()
     ->withPaths([
         __DIR__.DIRECTORY_SEPARATOR.'resources',
         __DIR__.DIRECTORY_SEPARATOR.'src',
-        __DIR__.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'content',
     ])
     ->withDefaultPrefix('')
     ->withIdentifiers(['phpicon', 'icon'])
-    ->withPlaceholder('�');
+    ->withPlaceholder('✽');

--- a/resources/views/snippets/partials/card-item.php
+++ b/resources/views/snippets/partials/card-item.php
@@ -16,6 +16,6 @@ $attrs = $item->url()->isNotEmpty() ? ' href="' . $item->url() . '" target="_bla
         <?php endif ?>
     </div>
     <?php if ($item->description()->isNotEmpty()) : ?>
-        <p class="text-sm text-neutral-400"><?= $item->description() ?></p>
+        <p class="text-sm text-neutral-400 hyphens-auto"><?= $item->description() ?></p>
     <?php endif ?>
 </<?= $tag ?>>

--- a/resources/views/templates/home.php
+++ b/resources/views/templates/home.php
@@ -87,7 +87,7 @@ use Kirby\Toolkit\I18n;
     <p class="text-md text-neutral-300">
         Une sélection de mes réalisations
     </p>
-    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 pt-4">
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:auto-rows-fr pt-4">
         <?php foreach (page()->worksRefs()->toStructure() as $item) { ?>
             <?php snippet('partials/card-item', ['item' => $item]) ?>
         <?php } ?>

--- a/src/content-icons.php
+++ b/src/content-icons.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * PHP-Icons Content Manifest
+ *
+ * php-icons only scans PHP files for icon() calls, but some icons are
+ * referenced dynamically from Kirby content files (.txt).
+ * This file declares those icons so they are discovered during scanning.
+ *
+ * Update this list when adding new icons via the Kirby panel.
+ */
+
+// Services
+icon('lucide:globe');
+icon('lucide:blocks');
+icon('lucide:lightbulb');
+icon('lucide:shield-check');


### PR DESCRIPTION
## Summary
This PR addresses php-icons configuration issues and improves UI consistency across the site. The main change involves creating a content manifest file to handle icons referenced dynamically from Kirby content files, since php-icons only scans PHP files.

## Key Changes

- **Created `src/content-icons.php`**: A new manifest file that declares icons used dynamically in Kirby content (`.txt` files) so they are discovered during the build process
- **Updated `php-icons.php` configuration**: 
  - Removed `storage/content` from scanned paths (no longer needed with the manifest approach)
  - Changed placeholder character from `�` to `✽` for better readability
- **Updated documentation**: Added important notes in both `CLAUDE.md` and `README.md` explaining that dynamically referenced icons must be declared in `src/content-icons.php`
- **Improved card item styling**: Added `hyphens-auto` class to description text for better text wrapping
- **Fixed grid layout**: Added `sm:auto-rows-fr` to works grid for consistent card heights on larger screens

## Implementation Details

The php-icons library scans PHP files for `icon()` function calls but cannot detect icons referenced through Kirby's dynamic content system. By creating a dedicated manifest file with explicit icon declarations, we ensure all icons are properly bundled during the build process without needing to scan content directories.

https://claude.ai/code/session_01AxhQbDFtnyT9h3dmDKhQpz